### PR TITLE
Optimise schema

### DIFF
--- a/webapp/models.py
+++ b/webapp/models.py
@@ -75,6 +75,36 @@ class CVE(Base):
         return packages
 
     @hybrid_property
+    def package_statuses(self):
+        packages = []
+        for package_name in self.packages:
+            statuses = []
+            for release, status in self.packages[package_name].items():
+                statuses.append(
+                    {
+                        "release_codename": status.release_codename,
+                        "status": status.status,
+                        "description": status.description,
+                        "component": status.component,
+                        "pocket": status.pocket,
+                    }
+                )
+
+            pkg = {
+                "name": package_name,
+                "source": f"https://ubuntu.com/security/cve?"
+                f"package={package_name}",
+                "ubuntu": f"https://packages.ubuntu.com/search?"
+                f"suite=all&section=all&arch=any&"
+                f"searchon=sourcenames&keywords={package_name}",
+                "debian": f"https://tracker.debian.org/pkg/{package_name}",
+                "statuses": statuses,
+            }
+            packages.append(pkg)
+
+        return packages
+
+    @hybrid_property
     def notices_ids(self):
         return [notice.id for notice in self.notices]
 

--- a/webapp/schemas.py
+++ b/webapp/schemas.py
@@ -89,7 +89,6 @@ class NoticeSchema(Schema):
     summary = String(required=True)
     instructions = String(required=True)
     references = List(String())
-    cves = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
     published = ParsedDateTime(required=True)
     description = String(allow_none=True)
     release_packages = Dict(
@@ -98,18 +97,13 @@ class NoticeSchema(Schema):
     )
 
 
-class NoticeModelSchema(Schema):
-    id = String(required=True, validate=Regexp(r"USN-\d{1,5}-\d{1,2}"))
-    title = String(required=True)
-    summary = String(required=True)
-    instructions = String(required=True)
-    references = List(String())
-    cves_ids = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
-    published = ParsedDateTime(required=True)
-    description = String(allow_none=True)
-    release_packages = Dict(
-        keys=ReleaseCodename(),
-        values=List(Nested(NoticePackage), required=True),
+class NoticeImportSchema(NoticeSchema):
+    cves = List(String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")))
+
+
+class NoticeAPISchema(NoticeSchema):
+    cves_ids = List(
+        String(validate=Regexp(r"(cve-|CVE-)\d{4}-\d{4,7}")), data_key="cves"
     )
 
 
@@ -158,49 +152,26 @@ class CVESchema(Schema):
     priority = String(allow_none=True)
     status = String(allow_none=True)
     cvss3 = Float(allow_none=True)
+    references = List(String())
+    bugs = List(String())
+    patches = Dict(
+        keys=String(),
+        values=List(String(), required=False),
+        allow_none=True,
+    )
+    tags = Dict(
+        keys=String(),
+        values=List(String(), required=False),
+        allow_none=True,
+    )
+
+
+class CVEImportSchema(CVESchema):
     packages = List(Nested(CvePackage))
-    references = List(String())
-    bugs = List(String())
-    patches = Dict(
-        keys=String(),
-        values=List(String(), required=False),
-        allow_none=True,
-    )
-    tags = Dict(
-        keys=String(),
-        values=List(String(), required=False),
-        allow_none=True,
-    )
 
 
-class CVEModelSchema(Schema):
-    id = String(required=True)
-    published = ParsedDateTime(allow_none=True)
-    description = String(allow_none=True)
-    ubuntu_description = String(allow_none=True)
-    notes = List(Nested(Note))
-    priority = String(allow_none=True)
-    cvss3 = Float(allow_none=True)
-    references = List(String())
-    patches = Dict(
-        keys=String(),
-        values=List(String(), required=False),
-        allow_none=True,
-    )
-    tags = Dict(
-        keys=String(),
-        values=List(String(), required=False),
-        allow_none=True,
-    )
-    bugs = List(String())
-    status = String(allow_none=True)
-    packages = Dict(
-        keys=String(),
-        values=Dict(
-            keys=String(),
-            values=Nested(Status),
-        ),
-    )
+class CVEAPISchema(CVESchema):
+    package_statuses = List(Nested(CvePackage), data_key="packages")
     notices_ids = List(
         String(validate=Regexp(r"USN-\d{1,5}-\d{1,2}")), required=False
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -3,10 +3,10 @@ from flask_apispec import marshal_with
 
 from webapp.database import db_session
 from webapp.models import CVE, Notice
-from webapp.schemas import CVEModelSchema, NoticeModelSchema
+from webapp.schemas import CVEAPISchema, NoticeAPISchema
 
 
-@marshal_with(CVEModelSchema, code=200)
+@marshal_with(CVEAPISchema, code=200)
 def get_cve(cve_id):
     cve = db_session.query(CVE).filter(CVE.id == cve_id).one_or_none()
 
@@ -19,7 +19,7 @@ def get_cve(cve_id):
     return cve
 
 
-@marshal_with(NoticeModelSchema, code=200)
+@marshal_with(NoticeAPISchema, code=200)
 def get_notice(notice_id):
     notice = (
         db_session.query(Notice).filter(Notice.id == notice_id).one_or_none()


### PR DESCRIPTION
Optimise schema for CVE and Notices. We have an import schema for CVE and Notices. The API uses also a schema to build CVE and Notices json responses. Ideally they are the same schema for each CVE and Notices.

Also slightly change the CVE schema to better match the CVESchema we already had.

## Issue / Card

Fixes #7
